### PR TITLE
Create base request

### DIFF
--- a/kin-utils/src/androidTest/java/kin/utils/FutureRequestTest.java
+++ b/kin-utils/src/androidTest/java/kin/utils/FutureRequestTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
-public class RequestTest {
+public class FutureRequestTest {
 
     private static final int TASK_DURATION_MILLIS = 100;
     private static final int TIMEOUT_DURATION_MILLIS = 500;
@@ -34,7 +34,7 @@ public class RequestTest {
                                 final Consumer<Exception> onErrorCallback)
         throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
-        Request<T> mockRequest = new Request<>(new Callable<T>() {
+        Request<T> mockRequest = new FutureRequest<>(new Callable<T>() {
             @Override
             public T call() throws Exception {
                 T result = task.call();
@@ -139,7 +139,7 @@ public class RequestTest {
         final CountDownLatch runLatch = new CountDownLatch(1);
         final AtomicBoolean threadInterrupted = new AtomicBoolean(false);
         final AtomicBoolean callbackExecuted = new AtomicBoolean(false);
-        Request<Object> mockRequest = new Request<>(new Callable<Object>() {
+        Request<Object> mockRequest = new FutureRequest<>(new Callable<Object>() {
             @Override
             public Object call() throws Exception {
                 try {
@@ -172,12 +172,12 @@ public class RequestTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void request_nullCallable() {
-        new Request<>(null);
+        new FutureRequest<>(null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void run_nullCallback() {
-        Request<String> request = new Request<>(new Callable<String>() {
+        Request<String> request = new FutureRequest<>(new Callable<String>() {
             @Override
             public String call() throws Exception {
                 return "";
@@ -188,7 +188,7 @@ public class RequestTest {
 
     @Test(expected = IllegalStateException.class)
     public void run_twice() {
-        Request<String> request = new Request<>(new Callable<String>() {
+        Request<String> request = new FutureRequest<>(new Callable<String>() {
             @Override
             public String call() throws Exception {
                 return "";
@@ -200,7 +200,7 @@ public class RequestTest {
 
     @Test(expected = IllegalStateException.class)
     public void runAfterCancel() {
-        Request<String> request = new Request<>(new Callable<String>() {
+        Request<String> request = new FutureRequest<>(new Callable<String>() {
             @Override
             public String call() throws Exception {
                 return "";

--- a/kin-utils/src/main/java/kin/utils/FutureRequest.java
+++ b/kin-utils/src/main/java/kin/utils/FutureRequest.java
@@ -1,0 +1,66 @@
+package kin.utils;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+/**
+ * Represents method invocation, each request will run sequentially on background thread,
+ * and will notify {@link ResultCallback} witch success or error on main thread.
+ *
+ * @param <T> request result type
+ */
+public class FutureRequest<T> extends Request<T> {
+
+    private static final ExecutorService executorService = Executors.newSingleThreadExecutor();
+    private final Callable<T> callable;
+    private Future<?> future;
+
+    public FutureRequest(Callable<T> callable) {
+        super();
+        checkNotNull(callable, "callable");
+        this.callable = callable;
+    }
+
+    @Override
+    public synchronized void run(ResultCallback<T> callback) {
+        super.run(callback);
+        submitFuture(callable);
+    }
+
+    private void submitFuture(final Callable<T> callable) {
+        future = executorService.submit(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    final T result = callable.call();
+                    handleResult(result);
+                } catch (final Exception e) {
+                    handleException(e);
+                }
+            }
+        });
+    }
+
+    /**
+     * Cancel {@code Request} and detach its callback,
+     * an attempt will be made to cancel ongoing request, if request has not run yet it will
+     * never run.
+     *
+     * @param mayInterruptIfRunning true if the request should be interrupted; otherwise,
+     *                              in-progress requests are
+     *                              allowed to complete
+     */
+    @Override
+    public synchronized void cancel(boolean mayInterruptIfRunning) {
+        if (!getIsCancelled()) {
+            if (future != null) {
+                future.cancel(mayInterruptIfRunning);
+            }
+            future = null;
+        }
+        super.cancel(mayInterruptIfRunning);
+    }
+
+}

--- a/kin-utils/src/main/java/kin/utils/Request.java
+++ b/kin-utils/src/main/java/kin/utils/Request.java
@@ -9,14 +9,14 @@ import android.os.Looper;
  *
  * @param <T> request result type
  */
-class Request<T> {
+public class Request<T> {
 
     private final Handler mainHandler;
     private boolean cancelled;
     private boolean executed;
     private ResultCallback<T> resultCallback;
 
-    Request() {
+    public Request() {
         this.mainHandler = new Handler(Looper.getMainLooper());
     }
 

--- a/kin-utils/src/main/java/kin/utils/Request.java
+++ b/kin-utils/src/main/java/kin/utils/Request.java
@@ -1,13 +1,7 @@
 package kin.utils;
 
-
 import android.os.Handler;
 import android.os.Looper;
-
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 
 /**
  * Represents method invocation, each request will run sequentially on background thread,
@@ -15,29 +9,80 @@ import java.util.concurrent.Future;
  *
  * @param <T> request result type
  */
-public class Request<T> {
+class Request<T> {
 
-    private static final ExecutorService executorService = Executors.newSingleThreadExecutor();
     private final Handler mainHandler;
-    private final Callable<T> callable;
     private boolean cancelled;
     private boolean executed;
-    private Future<?> future;
     private ResultCallback<T> resultCallback;
 
-    public Request(Callable<T> callable) {
-        checkNotNull(callable, "callable");
-        this.callable = callable;
+    Request() {
         this.mainHandler = new Handler(Looper.getMainLooper());
     }
 
     /**
      * Run request asynchronously, notify {@code callback} with successful result or error
      */
-    synchronized public void run(ResultCallback<T> callback) {
+    public synchronized void run(ResultCallback<T> callback) {
+        this.resultCallback = callback;
         checkBeforeRun(callback);
         executed = true;
-        submitFuture(callable, callback);
+    }
+
+    protected synchronized void executeOnMainThreadIfNotCancelled(Runnable runnable) {
+        if (!cancelled) {
+            mainHandler.post(runnable);
+        }
+    }
+
+    protected synchronized void handleResult(final T result) {
+        executeOnMainThreadIfNotCancelled(new Runnable() {
+
+            @Override
+            public void run() {
+                resultCallback.onResult(result);
+            }
+        });
+    }
+
+    protected synchronized void handleException(final Exception e) {
+        executeOnMainThreadIfNotCancelled(new Runnable() {
+
+            @Override
+            public void run() {
+                resultCallback.onError(e);
+            }
+        });
+    }
+
+    protected synchronized boolean getIsCancelled() {
+        return cancelled;
+    }
+
+    /**
+     * Cancel {@code Request} and detach its callback,
+     * an attempt will be made to cancel ongoing request, if request has not run yet it will never run.
+     *
+     * allowed to complete
+     */
+    public synchronized void cancel(boolean mayInterruptIfRunning) { // TODO: 2019-09-12 Dont
+        // really need here the 'mayInterruptIfRunning' it is just for backward compatibility
+        if (!cancelled) {
+            cancelled = true;
+            mainHandler.removeCallbacksAndMessages(null);
+            mainHandler.post(new Runnable() {
+                @Override
+                public void run() {
+                    resultCallback = null;
+                }
+            });
+        }
+    }
+
+    protected void checkNotNull(Object param, String name) {
+        if (param == null) {
+            throw new IllegalArgumentException(name + " cannot be null.");
+        }
     }
 
     private void checkBeforeRun(ResultCallback<T> callback) {
@@ -47,67 +92,6 @@ public class Request<T> {
         }
         if (cancelled) {
             throw new IllegalStateException("Request already cancelled.");
-        }
-    }
-
-    private void checkNotNull(Object param, String name) {
-        if (param == null) {
-            throw new IllegalArgumentException(name + " cannot be null.");
-        }
-    }
-
-    private void submitFuture(final Callable<T> callable, ResultCallback<T> callback) {
-        this.resultCallback = callback;
-        future = executorService.submit(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    final T result = callable.call();
-                    executeOnMainThreadIfNotCancelled(new Runnable() {
-                        @Override
-                        public void run() {
-                            resultCallback.onResult(result);
-                        }
-                    });
-                } catch (final Exception e) {
-                    executeOnMainThreadIfNotCancelled(new Runnable() {
-                        @Override
-                        public void run() {
-                            resultCallback.onError(e);
-                        }
-                    });
-                }
-            }
-        });
-    }
-
-    private synchronized void executeOnMainThreadIfNotCancelled(Runnable runnable) {
-        if (!cancelled) {
-            mainHandler.post(runnable);
-        }
-    }
-
-    /**
-     * Cancel {@code Request} and detach its callback,
-     * an attempt will be made to cancel ongoing request, if request has not run yet it will never run.
-     *
-     * @param mayInterruptIfRunning true if the request should be interrupted; otherwise, in-progress requests are
-     * allowed to complete
-     */
-    synchronized public void cancel(boolean mayInterruptIfRunning) {
-        if (!cancelled) {
-            cancelled = true;
-            if (future != null) {
-                future.cancel(mayInterruptIfRunning);
-            }
-            future = null;
-            mainHandler.removeCallbacksAndMessages(null);
-            mainHandler.post(new Runnable() {
-                @Override
-                public void run() {
-                    resultCallback = null;
-                }
-            });
         }
     }
 


### PR DESCRIPTION
Create future request class and a base request class and put common stuff in the base.
FutureRequest behaves exactly like the previous Request class.
The name of the "base request class is now Request so the API will not break.
But now in all our internal code, we will need to create it with new FutureRequest<T>(...) instead of new Request<T>(...)